### PR TITLE
fix: address continual drift in spacelift worker pool manifest resources

### DIFF
--- a/src/k8s.tf
+++ b/src/k8s.tf
@@ -212,4 +212,12 @@ resource "kubernetes_manifest" "spacelift_worker_pool" {
     kubernetes_role_v1.default,
     kubernetes_role_binding_v1.default
   ]
+
+  # Marks the field as managed by Kubernetes to avoid continually detecting drift
+  # https://github.com/hashicorp/terraform-provider-kubernetes/issues/1378
+  computed_fields = [
+    "metadata.annotations",
+    "metadata.labels",
+    "spec.pod.tolerations",
+  ]
 }


### PR DESCRIPTION
## Why

- Address continual drift in Kubernetes manifest resources for Spacelift worker groups:

```console
 # kubernetes_manifest.spacelift_worker_pool[0] will be updated in-place
  ~ resource "kubernetes_manifest" "spacelift_worker_pool" {
      ~ object   = {
          ~ spec       = {
              ~ pod                     = {
                  ~ tolerations                   = [
                      ~ {
                          + value             = (known after apply)
                            # (4 unchanged attributes hidden)
                        },
                      ~ {
                          + value             = (known after apply)
                            # (4 unchanged attributes hidden)
                        },
```

## What

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Usage

```sh
atmos terraform apply eks/spacelift-worker-pool -s <stack>
```

## Testing

- [X] Validated with `atmos validate stacks`
- [X] Performed successful `atmos terraform apply` on component

## References

- [Terraform Registry](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource configuration management to prevent unnecessary update detections. This enhancement leads to smoother deployment cycles and a more stable, uninterrupted user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->